### PR TITLE
Fix wrong path to download build artifacts on CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: build-output
+          path: build/
 
       - name: Deploy the app to `gh-pages`
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
`main` ブランチから `gh-pages` ブランチに対して正しくデプロイできていなかったため CI を修正