### PR TITLE
Hide summary marker iOS safari

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -171,6 +171,10 @@ header,
   list-style: none;
 }
 
+.menu-content ul li summary::-webkit-details-marker {
+  display:none;
+}
+
 .menu-content ul li details p {
   font-size: 12px;
   font-weight: 400;


### PR DESCRIPTION
summary の marker ▶️ が iOS + Safari で表示されてしまうので修正